### PR TITLE
Force TLS 1.2 support

### DIFF
--- a/CronofyCSharpSampleApp/Global.asax.cs
+++ b/CronofyCSharpSampleApp/Global.asax.cs
@@ -1,6 +1,7 @@
 ﻿using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
+using System.Net;
 
 namespace CronofyCSharpSampleApp
 {
@@ -8,6 +9,7 @@ namespace CronofyCSharpSampleApp
     {
         protected void Application_Start()
         {
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
             AreaRegistration.RegisterAllAreas();
             RouteConfig.RegisterRoutes(RouteTable.Routes);
         }


### PR DESCRIPTION
We've updated our minimum HTTPS protocols, but older versions of .NET default to insecure protocols which causes the connection to be closed.